### PR TITLE
fixed InvalidOperationError bug

### DIFF
--- a/awpy/parsers/rounds.py
+++ b/awpy/parsers/rounds.py
@@ -227,6 +227,9 @@ def apply_round_num(df: pl.DataFrame, rounds_df: pl.DataFrame, tick_col: str = "
         "round_num" column that indicates the round in which the event occurs. If no
         matching round is found, "round_num" will be null.
     """
+    # prevents InvalidOperationError on some demos in which the tick column isn't pre-sorted
+    df = df.sort(tick_col)
+
     # Use join_asof to get the round where round.start <= event.tick.
     # This join will add the columns 'round_num', 'start', and 'end' from rounds_df.
     df_with_round = df.join_asof(


### PR DESCRIPTION
issue was found trying to access any dataframe from map 1 of https://www.hltv.org/matches/2380994/betboom-vs-og-pgl-astana-2025-europe-closed-qualifier 

`"C:\Users\username\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\polars\lazyframe\frame.py", line 2332, in collect
    return wrap_df(ldf.collect(engine, callback))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.InvalidOperationError: argument in operation 'asof_join' is not sorted, please sort the 'expr/series/column' first` 
was raised
probably due to the tick column not being out of order

issue was fixed when I tested the change in a clean venv